### PR TITLE
Update from radius_km to radius metres

### DIFF
--- a/custom_components/whats_that_plane/__init__.py
+++ b/custom_components/whats_that_plane/__init__.py
@@ -203,7 +203,7 @@ class WhatsThatPlaneCoordinator(DataUpdateCoordinator):
             config = self.config
             your_latitude = config["latitude"]
             your_longitude = config["longitude"]
-            radius_km = config["radius_km"] * 1000
+            radius_metres = config["radius_metres"]
             minimum_altitude = config.get("filter_flight_altitude_ft_minimum", 0)
             maximum_altitude = config.get("filter_flight_altitude_ft_maximum", 60000)
             hold_seconds = config.get("hold_flight_data_seconds", 0)
@@ -213,7 +213,7 @@ class WhatsThatPlaneCoordinator(DataUpdateCoordinator):
 
 
             bounds = await self.hass.async_add_executor_job(
-                self.fr_api.get_bounds_by_point, your_latitude, your_longitude, radius_km
+                self.fr_api.get_bounds_by_point, your_latitude, your_longitude, radius_metres
             )
             all_flights = await self.hass.async_add_executor_job(
                 self.fr_api.get_flights, None, bounds
@@ -227,7 +227,7 @@ class WhatsThatPlaneCoordinator(DataUpdateCoordinator):
                     continue
 
                 flight_distance_km = geodesic((your_latitude, your_longitude), (flight.latitude, flight.longitude)).km
-                if flight_distance_km > config["radius_km"]:
+                if flight_distance_km * 1000 > config["radius_metres"]:
                     continue
 
                 flight_altitude_for_filter = flight.altitude if flight.altitude is not None else 0

--- a/custom_components/whats_that_plane/config_flow.py
+++ b/custom_components/whats_that_plane/config_flow.py
@@ -21,7 +21,7 @@ class WhatsThatPlaneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional("location_name"): str,
             vol.Required("latitude", default=default_latitude): vol.All(vol.Coerce(float), vol.Range(min=-90, max=90)),
             vol.Required("longitude", default=default_longitude): vol.All(vol.Coerce(float), vol.Range(min=-180, max=180)),
-            vol.Required("radius_km", default=5): vol.Coerce(int),
+            vol.Required("radius_metres", default=1000): vol.Coerce(int),
             vol.Required("facing_direction", default=0): vol.All(vol.Coerce(int), vol.Range(min=0, max=360)),
             vol.Required("fov_cone", default=90): vol.All(vol.Coerce(int), vol.Range(min=1, max=360)),
             vol.Required("update_interval", default=10): vol.All(vol.Coerce(int), vol.Range(min=1)),

--- a/custom_components/whats_that_plane/manifest.json
+++ b/custom_components/whats_that_plane/manifest.json
@@ -11,6 +11,6 @@
     "geopy==2.4.1",
     "pycountry==23.12.11"
   ],
-  "version": "2.0.0",
+  "version": "3.0.0",
   "iot_class": "cloud_polling"
 }

--- a/custom_components/whats_that_plane/manifest.json
+++ b/custom_components/whats_that_plane/manifest.json
@@ -1,15 +1,16 @@
 {
-    "domain": "whats_that_plane",
-    "name": "What's that plane?!",
-    "config_flow": true,
-    "documentation": "https://github.com/8bither0/whats-that-plane",
-    "issue_tracker": "https://github.com/8bither0/whats-that-plane/issues",
-    "codeowners": ["@8bither0"],
-    "requirements": [
-      "FlightRadarAPI==1.4.0",
-      "dpath==2.2.0",
-      "geopy==2.4.1"
-    ],
-    "version": "1.0.0",
-    "iot_class": "cloud_polling"
-  }
+  "domain": "whats_that_plane",
+  "name": "What's that plane?! (Leon's Fork)",
+  "config_flow": true,
+  "documentation": "https://github.com/LeonArmston/whats-that-plane-leon",
+  "issue_tracker": "https://github.com/LeonArmston/whats-that-plane-leon/issues",
+  "codeowners": ["@LeonArmston"],
+  "requirements": [
+    "FlightRadarAPI==1.4.0",
+    "dpath==2.2.0",
+    "geopy==2.4.1",
+    "pycountry==23.12.11"
+  ],
+  "version": "2.0.0",
+  "iot_class": "cloud_polling"
+}

--- a/custom_components/whats_that_plane/manifest.json
+++ b/custom_components/whats_that_plane/manifest.json
@@ -11,6 +11,6 @@
     "geopy==2.4.1",
     "pycountry==23.12.11"
   ],
-  "version": "3.0.0",
+  "version": "4.0.0",
   "iot_class": "cloud_polling"
 }

--- a/custom_components/whats_that_plane/sensor.py
+++ b/custom_components/whats_that_plane/sensor.py
@@ -331,7 +331,7 @@ class WhatsThatPlaneSensor(CoordinatorEntity, SensorEntity):
         config_attributes = {
             "latitude": config.get("latitude"),
             "longitude": config.get("longitude"),
-            "radius_km": config.get("radius_km"),
+            "radius_metres": config.get("radius_metres"),
             "facing_direction": config.get("facing_direction"),
             "fov_cone": config.get("fov_cone"),
             "distance_units": config.get("distance_units", "metric"),

--- a/custom_components/whats_that_plane/www/whats-that-plane-map.js
+++ b/custom_components/whats_that_plane/www/whats-that-plane-map.js
@@ -567,7 +567,7 @@ class WhatsThatPlaneMap extends HTMLElement {
     const locationIcon = L.divIcon({ html: `<svg viewbox="0 0 24 24" width="32" height="32" role="img" aria-hidden="true" style="color: #d32f2f; transform: translate3d(0, 0, 0);"><path fill="currentColor" d="M12,2C8.13,2 5,5.13 5,9C5,14.25 12,22 12,22S19,14.25 19,9C19,5.13 15.87,2 12,2M12,11.5A2.5,2.5 0 0,1 9.5,9A2.5,2.5 0 0,1 12,6.5A2.5,2.5 0 0,1 14.5,9A2.5,2.5 0 0,1 12,11.5Z" /></svg>`, className: '', iconSize: [32, 32], iconAnchor: [16, 32] });
     this._locationMarker = L.marker([config.latitude, config.longitude], { icon: locationIcon }).addTo(this._locationLayer).bindPopup("<b>My Location</b>");
 
-    const fovPoints = this._calculateFovCone(config.latitude, config.longitude, config.facing_direction, config.fov_cone, config.radius_km);
+  const fovPoints = this._calculateFovCone(config.latitude, config.longitude, config.facing_direction, config.fov_cone, config.radius_metres / 1000);
     this._fovCone = L.polygon(fovPoints, { color: 'green', fillOpacity: 0.05, opacity: 0.3, interactive: false }).addTo(this._locationLayer);
   }
 


### PR DESCRIPTION
This pull request introduces several updates to the "What's that plane?!" Home Assistant integration, with a primary focus on changing the configuration and internal logic from using a search radius in kilometers to meters, updating project metadata to reflect a new fork, and adding enhancements to flight data processing. The changes improve precision, compatibility, and enrich the sensor data available to users.

### Configuration and Units Changes
* The configuration option for search radius is changed from `radius_km` (kilometers) to `radius_metres` (meters) across the codebase, improving precision and consistency. This affects the config flow, data update logic, sensor attributes, and map rendering. [[1]](diffhunk://#diff-60259586fac3558893e768b8bebe76ca94afda3d1af366d4be8c67968044a3bcL206-R206) [[2]](diffhunk://#diff-60259586fac3558893e768b8bebe76ca94afda3d1af366d4be8c67968044a3bcL216-R216) [[3]](diffhunk://#diff-60259586fac3558893e768b8bebe76ca94afda3d1af366d4be8c67968044a3bcL230-R230) [[4]](diffhunk://#diff-af6245c936dba5fff069763a85779349e8cfe1707de391df19043f7324ec2e3dL24-R24) [[5]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aL272-R334) [[6]](diffhunk://#diff-8441a1a03aeb5edbc74055b21e2cdef2415a41e094b53b6828a432aa94a8a765L570-R570)

### Project Metadata and Requirements
* The `manifest.json` is updated to reflect the new fork (Leon's Fork), with updated documentation, issue tracker, code owner, and version. The `pycountry` library is added as a new requirement.

### Flight Data Enhancements
* Flight data formatting now includes flight number, compass heading (derived from numeric heading), and two-letter country codes for better compatibility with flag APIs. Helper methods for compass direction and country code conversion are added. [[1]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aR10-R14) [[2]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aR83-R133) [[3]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aR175-R183) [[4]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aR249) [[5]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aL206-R266) [[6]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aR276) [[7]](diffhunk://#diff-a82b78daf8f88184adb5d587d3381cdb6828193477386c2e9129efd2c7021e1aR287)

These changes collectively improve the usability, accuracy, and maintainability of the integration, while also laying groundwork for further enhancements and compatibility.